### PR TITLE
dx-text-media: JS files updated and insights Title and insights JS added

### DIFF
--- a/blocks/dx-text-media/dx-text-media.js
+++ b/blocks/dx-text-media/dx-text-media.js
@@ -1,11 +1,14 @@
+
     //Getting main Div container
     var mainDiv = document.querySelector('.dx-text-media');
     
      mainDiv.setAttribute('class','freeflowhtml');
-    var mainClassHeading =  document.querySelectorAll('.freeflowhtml > div > div')[0].textContent;
+     var mainClassHeading , paraContent , videoUrl , outsideRowanchorText;
+     
+   // var mainClassHeading =  document.querySelectorAll('.freeflowhtml > div > div')[0].textContent;
       //adding classNames to main Div
       mainDiv.classList.add('aem-GridColumn','aem-GridColumn--default--12');
-   
+  
     //creating section element
     var sectionElem = document.createElement('section');
     //adding Id to section
@@ -42,15 +45,15 @@
     //adding className to above Div
     InsideContainerSecondDiv.classList.add('h1-heading','text-center','mb50');
     //adding text to above div
-    InsideContainerSecondDiv.innerHTML = mainClassHeading;
-    InsideContainerFirstDiv.appendChild(InsideContainerSecondDiv);
+    // InsideContainerSecondDiv.innerHTML = mainClassHeading;
+    // InsideContainerFirstDiv.appendChild(InsideContainerSecondDiv);
 
     //Getting div container presented from plain.html For Hiding
     var InsideMainDiv = document.querySelector('.freeflowhtml > div');
     //Hiding the Inside Main Div From Plain Html
     InsideMainDiv.style.display = 'none';
-     var paraContent = document.querySelectorAll('.freeflowhtml > div > div')[1].textContent;
-     var videoUrl = document.querySelectorAll(".freeflowhtml > div > div")[2].textContent;
+    // var paraContent = document.querySelectorAll('.freeflowhtml > div > div')[1].textContent;
+    // var videoUrl = document.querySelectorAll(".freeflowhtml > div > div")[2].textContent;
     var InsideRowFirstDiv = document.createElement('div');
     //adding class to row Div
     InsideRowFirstDiv.classList.add('col-md-6','col-sm-12','col-xs-12','mb-sm-20','wow','fadeInLeft','animated');   
@@ -66,9 +69,8 @@
      var InsideRowPara = document.createElement('p');
     //adding class to para inside row Div
     InsideRowPara.setAttribute('class','para-ovr');
-  
-   InsideRowPara.innerHTML = paraContent;
-  InsideRowFirstDiv.appendChild(InsideRowPara);
+    // InsideRowPara.innerHTML = paraContent;
+    // InsideRowFirstDiv.appendChild(InsideRowPara);
 
 // Infosys Digital Experience (DX) powers businesses across the entire Customer Experience (CX) journey. We re-imagine, create and deliver integrated and personalized experiences by creating human-centered digital platforms. We help enterprises stay relevant by transforming business models, future proofing, bringing agility and responsiveness.
     //creating second div inside row Div
@@ -86,12 +88,14 @@
     //A variable that creates video tag to append in second div inside row Div 
     var InsideRowSecondDivVideo = document.createElement('video');
     // Local file to append in second div inside row Div 
-    
-    InsideRowSecondDivVideo.src = videoUrl;
+   // InsideRowSecondDivVideo.src = videoUrl;
     InsideRowSecondDivVideo.autoplay = true;
     InsideRowSecondDivVideo.loop = true;
     InsideRowSecondDivVideo.controls = true;
-    InsideRowSecondDiv.appendChild(InsideRowSecondDivVideo);
+   // InsideRowSecondDiv.appendChild(InsideRowSecondDivVideo);
+
+   
+
     //creating anchor tag after row Div
     var outsideRowanchor = document.createElement('a');
     //adding attribute to anchor tag after row Div 
@@ -107,7 +111,156 @@
     outsideRowanchor.style.animationDelay = '0.6s';
     //adding another attribute to anchor tag after row Div 
     outsideRowanchor.setAttribute('aria-label','Read More about undefined');
-    //setting data to anchor tag after row Div
-    outsideRowanchor.innerHTML = 'Read More';
+
+ for(let i=0; i < document.querySelectorAll('.freeflowhtml > div > div').length; i++){
+
+      if(i == 1){
+        mainClassHeading = document.querySelectorAll('.freeflowhtml > div > div')[i].textContent ;
+        InsideContainerSecondDiv.innerHTML = mainClassHeading;
+        InsideContainerFirstDiv.appendChild(InsideContainerSecondDiv);
+      }else if(i == 2){
+        paraContent = document.querySelectorAll('.freeflowhtml > div > div')[i].textContent ;
+        InsideRowPara.innerHTML = paraContent;
+        InsideRowFirstDiv.appendChild(InsideRowPara);
+      }else if(i == 3){
+        videoUrl = document.querySelectorAll('.freeflowhtml > div > div')[i].textContent ;
+        InsideRowSecondDivVideo.src = videoUrl;
+        InsideRowSecondDiv.appendChild(InsideRowSecondDivVideo);
+      }else if(i == 4){
+    outsideRowanchorText = document.querySelectorAll('.freeflowhtml > div > div')[i].textContent ;
+           //setting data to anchor tag after row Div
+    outsideRowanchor.innerHTML = outsideRowanchorText;
      articleElem.appendChild(outsideRowanchor);
-    // img tag inside video tag to append in second div inside row Div reference link: 'https://play.vidyard.com/RjFVtvoiRvUJSA1EGC2Cmf.jpg'
+      }
+    //  console.log( document.querySelectorAll('.freeflowhtml > div > div')[i].textContent);
+   }
+// img tag inside video tag to append in second div inside row Div reference link: 'https://play.vidyard.com/RjFVtvoiRvUJSA1EGC2Cmf.jpg'
+ //setting background banner
+// var a = document.querySelectorAll('.freeflowhtml > div > div')[0].querySelector('img').src;
+// document.querySelector('#overview').style.backgroundImage = "url(a)";
+
+//mainDiv.style.backgroundImage = "url(document.querySelectorAll('.freeflowhtml > div > div')[0].querySelector('img').src)";
+
+
+
+
+
+
+
+//     //Getting main Div container
+//     var mainDiv = document.querySelector('.dx-text-media');
+    
+//      mainDiv.setAttribute('class','freeflowhtml');
+//     var mainClassHeading =  document.querySelectorAll('.freeflowhtml > div > div')[0].textContent;
+//       //adding classNames to main Div
+//       mainDiv.classList.add('aem-GridColumn','aem-GridColumn--default--12');
+   
+//     //creating section element
+//     var sectionElem = document.createElement('section');
+//     //adding Id to section
+//     sectionElem.setAttribute('id','overview');
+//      mainDiv.appendChild(sectionElem);
+   
+//     //creating article
+//     var articleElem = document.createElement('article');
+//     //adding class to article
+//     articleElem.setAttribute('class','container');
+//      sectionElem.appendChild(articleElem);
+   
+//     //creating div
+//     var containerDiv = document.createElement('div');
+//     //adding class to container Div
+//     containerDiv.setAttribute('class','row');  
+//      articleElem.appendChild(containerDiv);
+   
+//     //creating div inside Div Container
+//     var InsideContainerFirstDiv = document.createElement('div');
+//     //adding className to container first Div
+//     InsideContainerFirstDiv.classList.add('col-md-8','col-md-offset-2','col-sm-12','col-xs-12','wow','fadeInUp','animated');
+//     //adding attribute to container first Div
+//     InsideContainerFirstDiv.setAttribute('data-wow-delay','0.3s');
+//     //Adding Inline CSS to container first Div
+//     InsideContainerFirstDiv.style.visibility = 'visible';
+//     InsideContainerFirstDiv.style.webkitAnimationDelay = '0.3s';
+//     InsideContainerFirstDiv.style.mozAnimationDelay = '0.3s';
+//     InsideContainerFirstDiv.style.animationDelay = '0.3s';
+//     containerDiv.appendChild(InsideContainerFirstDiv);
+    
+//     //Creating second Div inside Div Conatiner
+//     var InsideContainerSecondDiv = document.createElement('div');
+//     //adding className to above Div
+//     InsideContainerSecondDiv.classList.add('h1-heading','text-center','mb50');
+//     //adding text to above div
+//     InsideContainerSecondDiv.innerHTML = mainClassHeading;
+//     InsideContainerFirstDiv.appendChild(InsideContainerSecondDiv);
+
+//     //Getting div container presented from plain.html For Hiding
+//     var InsideMainDiv = document.querySelector('.freeflowhtml > div');
+//     //Hiding the Inside Main Div From Plain Html
+//     InsideMainDiv.style.display = 'none';
+//      var paraContent = document.querySelectorAll('.freeflowhtml > div > div')[1].textContent;
+//      var videoUrl = document.querySelectorAll(".freeflowhtml > div > div")[2].textContent;
+//     var InsideRowFirstDiv = document.createElement('div');
+//     //adding class to row Div
+//     InsideRowFirstDiv.classList.add('col-md-6','col-sm-12','col-xs-12','mb-sm-20','wow','fadeInLeft','animated');   
+//     //adding attribute to row para Div
+//     InsideRowFirstDiv.setAttribute('data-wow-delay','0.6s');
+//     //Adding Inline CSS to row para Div
+//     InsideRowFirstDiv.style.visibility = 'visible';
+//     InsideRowFirstDiv.style.webkitAnimationDelay = '0.6s';
+//     InsideRowFirstDiv.style.mozAnimationDelay = '0.6s';
+//     InsideRowFirstDiv.style.animationDelay = '0.6s';
+//     containerDiv.appendChild(InsideRowFirstDiv); 
+//      //creating para inside row Div
+//      var InsideRowPara = document.createElement('p');
+//     //adding class to para inside row Div
+//     InsideRowPara.setAttribute('class','para-ovr');
+  
+//    InsideRowPara.innerHTML = paraContent;
+//   InsideRowFirstDiv.appendChild(InsideRowPara);
+
+// // Infosys Digital Experience (DX) powers businesses across the entire Customer Experience (CX) journey. We re-imagine, create and deliver integrated and personalized experiences by creating human-centered digital platforms. We help enterprises stay relevant by transforming business models, future proofing, bringing agility and responsiveness.
+//     //creating second div inside row Div
+//     var InsideRowSecondDiv = document.createElement('div');
+//     //adding className to second div inside row Div 
+//     InsideRowSecondDiv.classList.add('col-md-6','col-sm-12','col-xs-12','mb-sm-20','wow','fadeInRight','animated');
+//     //adding attribute to second div inside row Div 
+//     InsideRowSecondDiv.setAttribute('data-wow-delay','0.6s');
+//     //Adding Inline CSS to second div inside row Div 
+//     InsideRowSecondDiv.style.visibility = 'visible';
+//     InsideRowSecondDiv.style.webkitAnimationDelay = '0.6s';
+//     InsideRowSecondDiv.style.mozAnimationDelay = '0.6s';
+//     InsideRowSecondDiv.style.animationDelay = '0.6s';
+//     containerDiv.appendChild(InsideRowSecondDiv);
+//     //A variable that creates video tag to append in second div inside row Div 
+//     var InsideRowSecondDivVideo = document.createElement('video');
+//     // Local file to append in second div inside row Div 
+    
+//     InsideRowSecondDivVideo.src = videoUrl;
+//     InsideRowSecondDivVideo.autoplay = true;
+//     InsideRowSecondDivVideo.loop = true;
+//     InsideRowSecondDivVideo.controls = true;
+//     InsideRowSecondDiv.appendChild(InsideRowSecondDivVideo);
+//     //creating anchor tag after row Div
+//     var outsideRowanchor = document.createElement('a');
+//     //adding attribute to anchor tag after row Div 
+//     outsideRowanchor.setAttribute('href','/services/digital-experience/overview.html');
+//     //adding class to anchor tag after row Div 
+//     outsideRowanchor.classList.add('btn','btn-shutter-more','insight-btn','wow','fadeInUp','animated');
+//     //adding attribute to anchor tag after row Div 
+//     outsideRowanchor.setAttribute('data-wow-delay','0.6s');
+//     //Adding Inline CSS to anchor tag after row Div 
+//     outsideRowanchor.style.visibility = 'visible';
+//     outsideRowanchor.style.webkitAnimationDelay = '0.6s';
+//     outsideRowanchor.style.mozAnimationDelay = '0.6s';
+//     outsideRowanchor.style.animationDelay = '0.6s';
+//     //adding another attribute to anchor tag after row Div 
+//     outsideRowanchor.setAttribute('aria-label','Read More about undefined');
+//     //setting data to anchor tag after row Div
+//     outsideRowanchor.innerHTML = 'Read More';
+//      articleElem.appendChild(outsideRowanchor);
+//     // img tag inside video tag to append in second div inside row Div reference link: 'https://play.vidyard.com/RjFVtvoiRvUJSA1EGC2Cmf.jpg'
+    
+//     //appending everything starts Here
+   
+//     //appending everything ends here

--- a/blocks/insight-title-description/insight-title-description.js
+++ b/blocks/insight-title-description/insight-title-description.js
@@ -1,0 +1,99 @@
+ //Getting main Div
+ var mainInsightTitleHeading = document.querySelector('.insight-title-description-wrapper > .insight-title-description');
+ //adding classNames to main Div
+mainInsightTitleHeading.setAttribute('class','titledescription');
+mainInsightTitleHeading.classList.add('aem-GridColumn','aem-GridColumn--default--12');
+//creating section element
+    var insightTitleSectionElem = document.createElement('section');
+    //adding Id to section
+    insightTitleSectionElem.setAttribute('class','pt75');
+     mainInsightTitleHeading.appendChild(insightTitleSectionElem);
+
+   //Getting div container presented from plain.html For Hiding
+    var InsideTitleMainDiv = document.querySelector('.titledescription > div');
+    //Hiding the Inside Main Div From Plain Html
+    InsideTitleMainDiv.style.display = 'none';
+
+    //creating article
+    var insightTitleArticleElem = document.createElement('article');
+    //adding class to article
+    insightTitleArticleElem.setAttribute('class','container');
+    insightTitleSectionElem.appendChild(insightTitleArticleElem);
+
+    //creating div
+    var containerTitleDiv = document.createElement('div');
+    //adding class to container Div
+    containerTitleDiv.setAttribute('class','row');  
+     insightTitleArticleElem.appendChild(containerTitleDiv);
+   
+    //creating div inside Div Container
+    var insightTitleContainerFirstDiv = document.createElement('div');
+    //adding className to container first Div
+    insightTitleContainerFirstDiv.classList.add('col-md-12', 'col-sm-12', 'col-xs-12', 'text-center', 'wow', 'fadeInDown', 'animated');
+    //adding attribute to container first Div
+    insightTitleContainerFirstDiv.setAttribute('data-wow-delay','0.3s');
+    //Adding Inline CSS to container first Div
+    insightTitleContainerFirstDiv.style.visibility = 'visible';
+    insightTitleContainerFirstDiv.style.webkitAnimationDelay = '0.3s';
+    insightTitleContainerFirstDiv.style.mozAnimationDelay = '0.3s';
+    insightTitleContainerFirstDiv.style.animationDelay = '0.3s';
+    containerTitleDiv.appendChild(insightTitleContainerFirstDiv);
+       //creating img tag
+    var containerImg = document.createElement('img');
+    //adding class to container img
+    containerImg.setAttribute('class','center-block');  
+    containerImg.setAttribute('alt','Line'); 
+   
+  //creating heading tag
+    var containerHeading = document.createElement('h2');
+    //adding class to container h2
+    containerHeading.setAttribute('class','h2-heading'); 
+   
+           //creating p tag
+    var containerPara = document.createElement('p');
+    //adding class to container p
+    containerPara.classList.add('col-md-8', 'col-md-offset-2', 'para-txt', 'light-gray', 'mb50');
+   
+    var imgsrclink , headingcontent , paragraphcontent ;
+            imgsrclink = document.querySelector('.titledescription  > div > div > picture >img').src
+            containerImg.src = imgsrclink;
+             insightTitleContainerFirstDiv.appendChild(containerImg);
+    for(let i=1; i < document.querySelectorAll('.titledescription > div > div').length; i++){
+          if(i == 1){
+            headingcontent = document.querySelectorAll('.titledescription > div > div')[1].innerText
+             containerHeading.innerHTML = headingcontent;
+           insightTitleContainerFirstDiv.appendChild(containerHeading);
+          }
+        if(i == 2){
+                headingcontent = document.querySelectorAll('.titledescription > div > div')[2].innerText
+                 containerPara.innerHTML = headingcontent;
+                insightTitleContainerFirstDiv.appendChild(containerPara);
+
+              }
+    }
+    
+
+// (function () {
+//     let desc = {}
+//     let targetELEMENT = document.querySelector(".insight-title-description")
+//     targetELEMENT.classList.add('titledescription','aem-GridColumn','aem-GridColumn--default--12')
+
+//     let newELEMENT = (desc) => {
+//         return `<section class="pt75">
+//                     <article class="container">
+//                         <div class="row">
+//                             <div class="col-md-12 col-sm-12 col-xs-12 text-center wow fadeInDown animated" data-wow-delay="0.3s" style="visibility: visible;-webkit-animation-delay: 0.3s; -moz-animation-delay: 0.3s; animation-delay: 0.3s;">
+//                                 <img src="${desc.imgsrc}" class="center-block" alt="Line">
+//                                 <h2 class="h2-heading">${desc.heading}</h2>
+//                                 <p class="col-md-8 col-md-offset-2 para-txt light-gray mb50">${desc.para}</p>
+//                             </div>
+//                         </div>
+//                     </article>
+//                 </section>`
+//     }
+//     let blockDATA = targetELEMENT.querySelectorAll('.insight-title-description.block > div > div')
+//     desc.imgsrc=blockDATA[0].querySelector('img').src
+//     desc.heading=blockDATA[1].textContent
+//     desc.para=blockDATA[2].textContent
+//     targetELEMENT.innerHTML=newELEMENT(desc)
+// })();

--- a/blocks/insights/insights.js
+++ b/blocks/insights/insights.js
@@ -1,0 +1,426 @@
+ //Getting main Div
+ var mainInsightHeading = document.querySelector('.insights-wrapper>.insights.block')
+ //adding classNames to main Div
+mainInsightHeading.setAttribute('class','insights');
+mainInsightHeading.classList.add('aem-GridColumn', 'aem-GridColumn--default--12');
+
+  //content Hiding from doc
+   var mainContentDoc = document.querySelectorAll('.insights-wrapper > .insights > div');
+  var index = 0, length = document.querySelectorAll('.insights-wrapper > .insights > div').length;
+    for ( ; index < length; index++) {
+     mainContentDoc[index].style.display = 'none';
+    }
+   
+
+   //creating section element
+    var insightSectionElem = document.createElement('section');
+    //adding Id to section
+    insightSectionElem.setAttribute('id','insights');
+    insightSectionElem.setAttribute('class','pb75');
+     mainInsightHeading.appendChild(insightSectionElem);
+
+    //creating article
+    var insightArticleElem = document.createElement('article');
+    //adding class to article
+    insightArticleElem.setAttribute('class','container');
+    insightSectionElem.appendChild(insightArticleElem);
+   
+    //creating div inside Div Container
+    var insightContainerFirstDiv = document.createElement('div');
+    //adding className to container first Div
+    insightContainerFirstDiv.classList.add('row', 'row-eq-ht', 'wow', 'fadeInUp', 'animated');
+    //adding attribute to container first Div
+    insightContainerFirstDiv.setAttribute('data-wow-delay','0.6s');
+    //Adding Inline CSS to container first Div
+    insightContainerFirstDiv.style.visibility = 'visible';
+    insightContainerFirstDiv.style.webkitAnimationDelay = '0.6s';
+    insightContainerFirstDiv.style.mozAnimationDelay = '0.6s';
+    insightContainerFirstDiv.style.animationDelay = '0.6s';
+    insightArticleElem.appendChild(insightContainerFirstDiv);
+
+    
+var commonImgclass , commonHeaderClass , commonParagraphClass , commonClassOne , commonClassTwo , commonClassThree;
+
+  var insightContentDiv = document.createElement('div');
+    insightContainerFirstDiv.appendChild(insightContentDiv);
+   insightContentDiv.classList.add('col-md-6', 'col-sm-12', 'col-xs-12', 'p0');
+    var blockDataImg = document.querySelectorAll('.insights > div');
+    var blockData = document.querySelectorAll('.insights > div > div');
+    var imgsrc = blockDataImg[0].querySelector('img').src;
+    var commonAnchor = document.createElement('a'); 
+    var commonDiv = document.createElement('div');
+    var commonMainDiv = document.createElement('div');
+    var commonMainSecDiv = document.createElement('div');
+    var commonImg = document.createElement('img');
+    var commonInsightHeader = document.createElement('h5');
+    var commonParagraph = document.createElement('p');
+    var data = document.querySelectorAll('#insights >.container > .row > div')[0];
+    var heading = blockData[1].textContent;
+    var hreflink = blockData[2].textContent;
+    var para = blockData[3].textContent;
+ 
+   // console.log(data);
+  commonAnchor.setAttribute('href',hreflink);
+  commonAnchor.setAttribute('target','_blank');
+  commonAnchor.setAttribute('title',para);
+  data.appendChild(commonAnchor);
+ 
+  commonClassOne = 'col-eq-ht';
+  commonDiv.setAttribute('class',commonClassOne);
+  commonAnchor.appendChild(commonDiv);
+
+  commonClassTwo = 'bg-color1';
+  commonMainDiv.setAttribute('class',commonClassTwo);
+  commonDiv.appendChild(commonMainDiv);
+
+  commonImgclass = 'img-responsive';
+  commonImg.setAttribute('class',commonImgclass);
+  commonImg.setAttribute('src',imgsrc);
+  commonImg.setAttribute('alt',para);
+  commonMainDiv.appendChild(commonImg);
+
+  commonClassThree = 'txt-reseach';
+  commonMainSecDiv.setAttribute('class',commonClassThree);
+  commonMainDiv.appendChild(commonMainSecDiv);
+
+   commonInsightHeader.setAttribute('class','insight-title');
+  commonInsightHeader.setAttribute('class','pb0');
+  commonInsightHeader.innerHTML = heading;
+  commonMainSecDiv.appendChild(commonInsightHeader);
+
+   commonParagraphClass = 'insight-text';
+   commonParagraph.setAttribute('class',commonParagraphClass);
+   commonParagraph.innerHTML = para;
+   commonMainSecDiv.appendChild(commonParagraph);
+
+ for(let i=2;i < document.querySelectorAll('.insights > div').length; i++){
+     
+     let insightContentDiv = document.createElement('div');
+    insightContainerFirstDiv.appendChild(insightContentDiv);
+   insightContentDiv.classList.add('col-md-3', 'col-sm-6', 'col-xs-12', 'p0');
+
+      var commonImgOneclass , 
+      commonHeaderOneClass ,
+      commonParagraphOneClass ,
+      commonSubParagraphClass ,
+      commonClassOnee , 
+      commonClassTwoo ,
+      commonClassThreee;
+    var commonInsightTwoAnchor = document.createElement('a');
+    var commonInsightTwoDiv = document.createElement('div');
+    var commonInsightTwoMainDiv = document.createElement('div');
+    var commonInsightTwoMainThrdDiv = document.createElement('div');
+    var commonInsightTwoImg = document.createElement('img');
+    var commonInsightTwoHeader = document.createElement('h5');
+    var commonInsightTwoParagraph = document.createElement('p');
+    var commonInsightTwoSubParagraph = document.createElement('p');
+  
+ if(i == 2){
+
+    var imgsrcOne = document.querySelectorAll('.insights > div')[1].querySelector('img').src;
+
+    var dataOne = document.querySelectorAll('#insights >.container > .row > div')[1];
+    var InsightTwoheading = document.querySelectorAll('.insights > div > div')[5].textContent;
+    var InsightTwohreflink = document.querySelectorAll('.insights > div > div')[6].textContent;
+    var InsightTwopara = document.querySelectorAll('.insights > div > div')[7].textContent;
+    var InsightsubPara = document.querySelectorAll('.insights > div > div')[8].textContent;
+
+  commonInsightTwoAnchor.setAttribute('href',InsightTwohreflink);
+  commonInsightTwoAnchor.setAttribute('target','_blank');
+  commonInsightTwoAnchor.setAttribute('title',InsightTwopara);
+  dataOne.appendChild(commonInsightTwoAnchor);
+ 
+  commonClassOnee = 'col-eq-ht';
+  commonInsightTwoDiv.setAttribute('class',commonClassOnee);
+  commonInsightTwoDiv.classList.add('bg-blog');
+  commonInsightTwoAnchor.appendChild(commonInsightTwoDiv);
+
+  commonClassTwoo = 'txt-section';
+  commonInsightTwoMainDiv.setAttribute('class',commonClassTwoo);
+  commonInsightTwoDiv.appendChild(commonInsightTwoMainDiv);
+
+  commonClassThreee = 'txt-blog';
+  commonInsightTwoMainThrdDiv.setAttribute('class',commonClassThreee);
+  commonInsightTwoMainDiv.appendChild(commonInsightTwoMainThrdDiv);
+    
+  commonHeaderOneClass = 'insight-title';
+  commonInsightTwoHeader.setAttribute('class',commonHeaderOneClass);
+  commonInsightTwoHeader.classList.add('color-onyx-m');
+  commonInsightTwoHeader.innerHTML = InsightTwoheading;
+  commonInsightTwoMainThrdDiv.appendChild(commonInsightTwoHeader);
+    
+  commonImgOneclass = 'img-responsive';
+  commonInsightTwoImg.setAttribute('class',commonImgOneclass);
+  commonInsightTwoImg.classList.add('center-block', 'pt20');
+  commonInsightTwoImg.setAttribute('src',imgsrcOne);
+  commonInsightTwoImg.setAttribute('alt',InsightTwopara);
+  commonInsightTwoMainThrdDiv.appendChild(commonInsightTwoImg);
+
+   commonParagraphOneClass = 'size-md-20';    
+   commonInsightTwoParagraph.setAttribute('class',commonParagraphOneClass);
+   commonInsightTwoParagraph.classList.add('fontweight400', 'black-color', 'line-height-26', 'pt10');
+   commonInsightTwoParagraph.innerHTML = InsightTwopara;
+   commonInsightTwoMainThrdDiv.appendChild(commonInsightTwoParagraph);
+
+   commonSubParagraphClass = 'more';
+   commonInsightTwoSubParagraph.setAttribute('class',commonSubParagraphClass);
+    commonInsightTwoSubParagraph.classList.add('black-color', 'readmore-top');
+   commonInsightTwoSubParagraph.innerHTML = InsightsubPara;
+   commonInsightTwoMainThrdDiv.appendChild(commonInsightTwoSubParagraph);
+  }  else  if(i == 3){
+
+    var dataTwo = document.querySelectorAll('#insights >.container > .row > div')[2];
+    var InsightTwoheading = document.querySelectorAll('.insights > div > div')[9].textContent;
+    var InsightTwohreflink = document.querySelectorAll('.insights > div > div')[10].textContent;
+    var InsightTwopara = document.querySelectorAll('.insights > div > div')[11].textContent;
+    var InsightsubPara = document.querySelectorAll('.insights > div > div')[12].textContent;
+
+  commonInsightTwoAnchor.setAttribute('href',InsightTwohreflink);
+  commonInsightTwoAnchor.setAttribute('target','_blank');
+  commonInsightTwoAnchor.setAttribute('title',InsightTwopara);
+  dataTwo.appendChild(commonInsightTwoAnchor);
+ 
+  commonClassOnee = 'col-eq-ht';
+  commonInsightTwoDiv.setAttribute('class',commonClassOnee);
+  commonInsightTwoDiv.classList.add('bg-pressrelease');
+  commonInsightTwoAnchor.appendChild(commonInsightTwoDiv);
+
+  commonClassTwoo = 'txt-section';
+  commonInsightTwoMainDiv.setAttribute('class',commonClassTwoo);
+  commonInsightTwoDiv.appendChild(commonInsightTwoMainDiv);
+
+  commonClassThreee = 'txt-blog';
+  commonInsightTwoMainThrdDiv.setAttribute('class',commonClassThreee);
+  commonInsightTwoMainDiv.appendChild(commonInsightTwoMainThrdDiv);
+    
+  commonHeaderOneClass = 'insight-title';
+  commonInsightTwoHeader.setAttribute('class',commonHeaderOneClass);
+  commonInsightTwoHeader.classList.add('white-color');
+  commonInsightTwoHeader.innerHTML = InsightTwoheading;
+  commonInsightTwoMainThrdDiv.appendChild(commonInsightTwoHeader);
+
+   commonParagraphOneClass = 'size-md-20';    
+   commonInsightTwoParagraph.setAttribute('class',commonParagraphOneClass);
+   commonInsightTwoParagraph.classList.add('fontweight400', 'white-color', 'line-height-26', 'pt40');
+   commonInsightTwoParagraph.innerHTML = InsightTwopara;
+   commonInsightTwoMainThrdDiv.appendChild(commonInsightTwoParagraph);
+
+   commonSubParagraphClass = 'more';
+   commonInsightTwoSubParagraph.setAttribute('class',commonSubParagraphClass);
+    commonInsightTwoSubParagraph.classList.add('readmore-top', 'white-color');
+   commonInsightTwoSubParagraph.innerHTML = InsightsubPara;
+   commonInsightTwoMainThrdDiv.appendChild(commonInsightTwoSubParagraph);
+ }  else  if(i == 4){
+
+    var dataThree = document.querySelectorAll('#insights >.container > .row > div')[3];
+    var InsightTwoheading = document.querySelectorAll('.insights > div > div')[13].textContent;
+    var InsightTwohreflink = document.querySelectorAll('.insights > div > div')[14].textContent;
+    var InsightTwopara = document.querySelectorAll('.insights > div > div')[15].textContent;
+    var InsightsubPara = document.querySelectorAll('.insights > div > div')[16].textContent;
+
+  commonInsightTwoAnchor.setAttribute('href',InsightTwohreflink);
+  commonInsightTwoAnchor.setAttribute('target','_blank');
+  commonInsightTwoAnchor.setAttribute('title',InsightTwopara);
+  dataThree.appendChild(commonInsightTwoAnchor);
+ 
+  commonClassOnee = 'col-eq-ht';
+  commonInsightTwoDiv.setAttribute('class',commonClassOnee);
+  commonInsightTwoDiv.classList.add('bg-blog');
+  commonInsightTwoAnchor.appendChild(commonInsightTwoDiv);
+
+  commonClassTwoo = 'txt-section';
+  commonInsightTwoMainDiv.setAttribute('class',commonClassTwoo);
+  commonInsightTwoDiv.appendChild(commonInsightTwoMainDiv);
+
+  commonClassThreee = 'txt-blog';
+  commonInsightTwoMainThrdDiv.setAttribute('class',commonClassThreee);
+  commonInsightTwoMainDiv.appendChild(commonInsightTwoMainThrdDiv);
+    
+  commonHeaderOneClass = 'insight-title';
+  commonInsightTwoHeader.setAttribute('class',commonHeaderOneClass);
+  commonInsightTwoHeader.classList.add('color-onyx-m');
+  commonInsightTwoHeader.innerHTML = InsightTwoheading;
+  commonInsightTwoMainThrdDiv.appendChild(commonInsightTwoHeader);
+
+   commonParagraphOneClass = 'size-md-20';    
+   commonInsightTwoParagraph.setAttribute('class',commonParagraphOneClass);
+   commonInsightTwoParagraph.classList.add('fontweight400', 'black-color', 'line-height-26', 'pt40');
+   commonInsightTwoParagraph.innerHTML = InsightTwopara;
+   commonInsightTwoMainThrdDiv.appendChild(commonInsightTwoParagraph);
+
+   commonSubParagraphClass = 'more';
+   commonInsightTwoSubParagraph.setAttribute('class',commonSubParagraphClass);
+    commonInsightTwoSubParagraph.classList.add('black-color');
+   commonInsightTwoSubParagraph.innerHTML = InsightsubPara;
+   commonInsightTwoMainThrdDiv.appendChild(commonInsightTwoSubParagraph);
+ } else  if(i == 5){
+
+    var dataFour = document.querySelectorAll('#insights >.container > .row > div')[4];
+    var InsightTwoheading = document.querySelectorAll('.insights > div > div')[17].textContent;
+    var InsightTwohreflink = document.querySelectorAll('.insights > div > div')[18].textContent;
+    var InsightTwopara = document.querySelectorAll('.insights > div > div')[19].textContent;
+    var InsightsubPara = document.querySelectorAll('.insights > div > div')[20].textContent;
+
+  commonInsightTwoAnchor.setAttribute('href',InsightTwohreflink);
+  commonInsightTwoAnchor.setAttribute('target','_blank');
+  commonInsightTwoAnchor.setAttribute('title',InsightTwopara);
+  dataFour.appendChild(commonInsightTwoAnchor);
+ 
+  commonClassOnee = 'col-eq-ht';
+  commonInsightTwoDiv.setAttribute('class',commonClassOnee);
+  commonInsightTwoDiv.classList.add('bg-article');
+  commonInsightTwoAnchor.appendChild(commonInsightTwoDiv);
+
+  commonClassTwoo = 'txt-section';
+  commonInsightTwoMainDiv.setAttribute('class',commonClassTwoo);
+  commonInsightTwoDiv.appendChild(commonInsightTwoMainDiv);
+
+  commonClassThreee = 'txt-blog';
+  commonInsightTwoMainThrdDiv.setAttribute('class',commonClassThreee);
+  commonInsightTwoMainDiv.appendChild(commonInsightTwoMainThrdDiv);
+    
+  commonHeaderOneClass = 'insight-title';
+  commonInsightTwoHeader.setAttribute('class',commonHeaderOneClass);
+  commonInsightTwoHeader.classList.add('white-color');
+  commonInsightTwoHeader.innerHTML = InsightTwoheading;
+  commonInsightTwoMainThrdDiv.appendChild(commonInsightTwoHeader);
+
+   commonParagraphOneClass = 'size-md-20';    
+   commonInsightTwoParagraph.setAttribute('class',commonParagraphOneClass);
+   commonInsightTwoParagraph.classList.add('fontweight400', 'white-color', 'line-height-26', 'pt40');
+   commonInsightTwoParagraph.innerHTML = InsightTwopara;
+   commonInsightTwoMainThrdDiv.appendChild(commonInsightTwoParagraph);
+
+   commonSubParagraphClass = 'more';
+   commonInsightTwoSubParagraph.setAttribute('class',commonSubParagraphClass);
+    commonInsightTwoSubParagraph.classList.add('white-color');
+   commonInsightTwoSubParagraph.innerHTML = InsightsubPara;
+   commonInsightTwoMainThrdDiv.appendChild(commonInsightTwoSubParagraph);
+ } else  if(i == 6){
+
+    var imgsrcSix = document.querySelectorAll('.insights > div')[5].querySelector('img').src;
+
+    var dataFive = document.querySelectorAll('#insights >.container > .row > div')[5];
+    var InsightTwoheading = document.querySelectorAll('.insights > div > div')[22].textContent;
+    var InsightTwohreflink = document.querySelectorAll('.insights > div > div')[23].textContent;
+    var InsightTwopara = document.querySelectorAll('.insights > div > div')[24].textContent;
+    var InsightsubPara = document.querySelectorAll('.insights > div > div')[25].textContent;
+
+  commonInsightTwoAnchor.setAttribute('href',InsightTwohreflink);
+  commonInsightTwoAnchor.setAttribute('target','_blank');
+  commonInsightTwoAnchor.setAttribute('title',InsightTwopara);
+  dataFive.appendChild(commonInsightTwoAnchor);
+ 
+  commonClassOnee = 'col-eq-ht';
+  commonInsightTwoDiv.setAttribute('class',commonClassOnee);
+  commonInsightTwoDiv.classList.add('bg-blog');
+  commonInsightTwoAnchor.appendChild(commonInsightTwoDiv);
+
+  commonClassTwoo = 'bg-whitepaper';
+  commonInsightTwoMainDiv.setAttribute('class',commonClassTwoo);
+  commonInsightTwoDiv.appendChild(commonInsightTwoMainDiv);
+
+  commonImgOneclass = 'img-responsive';
+  commonInsightTwoImg.setAttribute('class',commonImgOneclass);
+  commonInsightTwoImg.classList.add('img-whitepaper');
+  commonInsightTwoImg.setAttribute('src',imgsrcSix);
+  commonInsightTwoImg.setAttribute('alt',InsightTwopara);
+  commonInsightTwoMainDiv.appendChild(commonInsightTwoImg);
+  
+  commonClassThreee = 'txt-section';
+  commonInsightTwoMainThrdDiv.setAttribute('class',commonClassThreee);
+  commonInsightTwoMainDiv.appendChild(commonInsightTwoMainThrdDiv);
+    
+  commonHeaderOneClass = 'insight-title';
+  commonInsightTwoHeader.setAttribute('class',commonHeaderOneClass);
+  commonInsightTwoHeader.classList.add('white-color');
+  commonInsightTwoHeader.innerHTML = InsightTwoheading;
+  commonInsightTwoMainThrdDiv.appendChild(commonInsightTwoHeader);
+    
+  var divOne , divTwo , divThree ;
+   divOne = document.createElement('div');
+   divTwo = document.createElement('div');
+   divThree = document.createElement('div');
+
+  divOne.setAttribute('class','txt-whitepaper');
+  commonInsightTwoMainThrdDiv.appendChild(divOne);
+
+   divTwo.setAttribute('class','corner-shape');
+   divOne.appendChild(divTwo);
+
+   divThree.setAttribute('class','corner-shape-text');
+   divTwo.appendChild(divThree);
+  
+   commonParagraphOneClass = 'whitepaper';    
+   commonInsightTwoParagraph.setAttribute('class',commonParagraphOneClass);
+   commonInsightTwoParagraph.innerHTML = InsightTwopara;
+   divThree.appendChild(commonInsightTwoParagraph);
+
+   commonSubParagraphClass = 'white-download';
+   commonInsightTwoSubParagraph.setAttribute('class',commonSubParagraphClass);
+   commonInsightTwoSubParagraph.classList.add('white-color');
+   commonInsightTwoSubParagraph.innerHTML = InsightsubPara;
+   divThree.appendChild(commonInsightTwoSubParagraph);
+  }  else  if(i == 7){
+
+    var dataSix = document.querySelectorAll('#insights >.container > .row > div')[6];
+    var InsightTwoheading = document.querySelectorAll('.insights > div > div')[26].textContent;
+    var InsightTwohreflink = document.querySelectorAll('.insights > div > div')[27].textContent;
+    var InsightTwopara = document.querySelectorAll('.insights > div > div')[28].textContent;
+    var InsightsubPara = document.querySelectorAll('.insights > div > div')[29].textContent;
+
+  commonInsightTwoAnchor.setAttribute('href',InsightTwohreflink);
+  commonInsightTwoAnchor.setAttribute('target','_blank');
+  commonInsightTwoAnchor.setAttribute('title',InsightTwopara);
+  dataSix.appendChild(commonInsightTwoAnchor);
+ 
+  commonClassOnee = 'col-eq-ht';
+  commonInsightTwoDiv.setAttribute('class',commonClassOnee);
+  commonInsightTwoDiv.classList.add('bg-last');
+  commonInsightTwoAnchor.appendChild(commonInsightTwoDiv);
+
+  commonClassTwoo = 'txt-section';
+  commonInsightTwoMainDiv.setAttribute('class',commonClassTwoo);
+  commonInsightTwoDiv.appendChild(commonInsightTwoMainDiv);
+
+  commonClassThreee = 'txt-blog';
+  commonInsightTwoMainThrdDiv.setAttribute('class',commonClassThreee);
+  commonInsightTwoMainDiv.appendChild(commonInsightTwoMainThrdDiv);
+    
+  commonHeaderOneClass = 'insight-title';
+  commonInsightTwoHeader.setAttribute('class',commonHeaderOneClass);
+  commonInsightTwoHeader.classList.add('white-color');
+  commonInsightTwoHeader.innerHTML = InsightTwoheading;
+  commonInsightTwoMainThrdDiv.appendChild(commonInsightTwoHeader);
+
+   commonParagraphOneClass = 'size-md-20';    
+   commonInsightTwoParagraph.setAttribute('class',commonParagraphOneClass);
+   commonInsightTwoParagraph.classList.add('fontweight400', 'white-color', 'line-height-26', 'pt40');
+   commonInsightTwoParagraph.innerHTML = InsightTwopara;
+   commonInsightTwoMainThrdDiv.appendChild(commonInsightTwoParagraph);
+
+   commonSubParagraphClass = 'more';
+   commonInsightTwoSubParagraph.setAttribute('class',commonSubParagraphClass);
+    commonInsightTwoSubParagraph.classList.add('white-color');
+   commonInsightTwoSubParagraph.innerHTML = InsightsubPara;
+   commonInsightTwoMainThrdDiv.appendChild(commonInsightTwoSubParagraph);
+  } 
+  
+ }
+ var endingAnchor = document.createElement('a');
+ var insightContentOne = document.querySelectorAll('.insights > div > div')[30].textContent;
+ var insightContentTwo = document.querySelectorAll('.insights > div > div')[31].textContent;
+  endingAnchor.setAttribute('href',insightContentOne);
+  endingAnchor.setAttribute('target','_self');
+  endingAnchor.setAttribute('title',insightContentTwo);
+  endingAnchor.classList.add('btn', 'btn-shutter-more', 'insight-btn', 'wow', 'fadeInUp', 'animated');
+    //adding attribute to container first Div
+    endingAnchor.setAttribute('data-wow-delay','0.9s');
+    //Adding Inline CSS to container first Div
+    endingAnchor.style.visibility = 'visible';
+    endingAnchor.style.webkitAnimationDelay = '0.9s';
+    endingAnchor.style.mozAnimationDelay = '0.9s';
+    endingAnchor.style.animationDelay = '0.9s';
+    endingAnchor.innerHTML = insightContentTwo;
+  insightArticleElem.appendChild(endingAnchor);
+ 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

//Message starts Here
dx-text-media.js updated and insights-Title and insights blocks added with folder and JS.
In dx-text-media : can you add one column at end in doc(dx-text-media block content) to get/render "read more"
In request-for-services : can you add insights-title and insights content in DOC as per reference attached in teams :

 
Test URLs:
- Before: https://main--<repo>--<owner>.hlx.page/
- After: https://<branch>--<repo>--<owner>.hlx.page/
